### PR TITLE
Moved routes declaration from app.module to app-routing.module

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,8 +1,24 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { MenuComponent } from "./components/pages/menu/menu.component";
+import { StatsComponent } from "./components/pages/stats/stats.component";
+import { ReseauxComponent } from "./components/pages/reseaux/reseaux.component";
+import { StaffComponent } from "./components/pages/staff/staff.component";
+import { MissionsComponent } from "./components/pages/missions/missions.component";
+import { OptionsComponent } from "./components/pages/options/options.component";
+import { HowConnectComponent } from "./components/pages/how-connect/how-connect.component";
+import { NotFoundComponent } from "./components/pages/not-found/not-found.component";
 
 const routes: Routes = [
-    
+  {path: 'menu', component: MenuComponent},
+  {path: '', component: MenuComponent},
+  {path: 'stats', component: StatsComponent},
+  {path: 'reseaux', component: ReseauxComponent},
+  {path: 'staff', component: StaffComponent},
+  {path: 'missions', component: MissionsComponent},
+  {path: 'options', component: OptionsComponent},
+  {path: 'how-connect', component: HowConnectComponent},
+  {path: '**', component: NotFoundComponent}
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,5 @@
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
-import {RouterModule, Routes} from "@angular/router";
 import {CookieService} from 'ngx-cookie-service';
 
 
@@ -33,18 +32,6 @@ import {BadgeComponent} from './components/pages/options/components/badge/badge.
 import {ThemeSwitcherComponent} from './components/global/theme-switcher/theme-switcher.component';
 import {HowConnectComponent} from './components/pages/how-connect/how-connect.component';
 
-const appRoutes: Routes = [
-    {path: 'menu', component: MenuComponent},
-    {path: '', component: MenuComponent},
-    {path: 'stats', component: StatsComponent},
-    {path: 'reseaux', component: ReseauxComponent},
-    {path: 'staff', component: StaffComponent},
-    {path: 'missions', component: MissionsComponent},
-    {path: 'options', component: OptionsComponent},
-    {path: 'how-connect', component: HowConnectComponent},
-    {path: '**', component: NotFoundComponent}
-]
-
 @NgModule({
     declarations: [
         AppComponent,
@@ -73,8 +60,7 @@ const appRoutes: Routes = [
     imports: [
         BrowserModule,
         AppRoutingModule,
-        HttpClientModule,
-        RouterModule.forRoot(appRoutes)
+        HttpClientModule
     ],
     providers: [
         CookieService


### PR DESCRIPTION
Given that app-routing.modulet.ts does exist in the application and his intended to deal with routing and routes themselves before, I moved the routes into it.